### PR TITLE
fix error: label at end of compound statement

### DIFF
--- a/lk2nd/boot/extlinux.c
+++ b/lk2nd/boot/extlinux.c
@@ -222,6 +222,7 @@ static int parse_conf(char *data, size_t size, struct label *label)
 				}
 				break;
 			default:
+				break;
 		}
 	}
 


### PR DESCRIPTION
My envirment: `Ubuntu 20.04`, `gcc-arm-none-eabi: 15:9-2019-q4-0ubuntu1`
When I tried to compile lk2nd with `make TOOLCHAIN_PREFIX=arm-none-eabi- lk2nd-msm8952`, meet error :
```
  lk2nd/boot/extlinux.c: In function 'parse_conf':
  lk2nd/boot/extlinux.c:224:4: error: label at end of compound statement
    224 |    default:
        |    ^~~~~~~
  make[1]: *** [arch/arm/compile.mk:5: build-lk2nd-msm8952/lk2nd/boot/extlinux.o] Error 1
```
I fixed this by added break after default case.
